### PR TITLE
Add a more robust .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Ignore Vim files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+Session.vim
+.netrwhist
+*~
+tags
+
+# Ignore macOS files
+*.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/.gitignore/.gitignore
+++ b/.gitignore/.gitignore
@@ -1,2 +1,0 @@
-/.project
-/.DS_Store


### PR DESCRIPTION
Previously, our .gitignore was only configured to ignore minimal
filetypes. Now we are ignoring many commonly unneeded files.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>