### PR TITLE
Update GitHub link text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
     <div class="infobox">
       <img class="github" src="./images/github.svg"></img>
       <div class="infoarea" id="infoarea">clicking on a tile leads you through a step by step process for creating content on
-        <a class="githublink" href="https://github.com/IBM"> IBM's GitHub Account</a></div>
+        <a class="githublink" href="https://github.com/IBM"> IBM's GitHub Organization</a></div>
     </div>
     <div class="detailbox">
       <div class="detailpitch">


### PR DESCRIPTION
Update text to reflect that github.com/IBM is the page for IBM's GitHub
org, not a specific account.

Related-Issue: #25
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>