### PR TITLE
Add checklists to publication types

### DIFF
--- a/public/data/publications.json
+++ b/public/data/publications.json
@@ -10,7 +10,7 @@
       },
       {
         "order": 2,
-        "comment": "What is it's advocacy potential?"
+        "comment": "What is its advocacy potential?"
       },
       {
         "order": 3,
@@ -18,7 +18,7 @@
       },
       {
         "order": 4,
-        "comment": "What is it's priority?"
+        "comment": "What is its priority?"
       },
       {
         "order": 5,
@@ -46,7 +46,7 @@
       },
       {
         "order": 11,
-        "comment": "Does this pattern highlight an IBM product advantage vs market product"
+        "comment": "Does this pattern highlight an IBM product advantage vs market product?"
       }
     ]
   },
@@ -63,14 +63,87 @@
     "repo": "https://github.com/IBM/incubator/blob/master",
     "file": "how-to.md",
     "icon": "howto.svg",
-    "checklist":[]
-  }, {
+    "checklist":[{
+        "order": 1,
+        "comment": "Title of the how-to you want to create"
+      },
+      {
+        "order": 2,
+        "comment": "Brief description of the how-to steps"
+      },
+      {
+        "order": 3,
+        "comment": "List of technologies you will be highlighting"
+      },
+      {
+        "order": 4,
+        "comment": "What the how-to accomplishes"
+      },
+      {
+        "order": 5,
+        "comment": "Why this is a good solution"
+      },
+      {
+        "order": 6,
+        "comment": "Who is the target audience?"
+      },
+      {
+        "order": 7,
+        "comment": "Which business unit you report to"
+      }
+    ]
+  },
+  {
     "type": "tech talk",
     "description": "Tech talks are 30 minute presentations, scheduled and broadcast over the web",
     "repo": "https://github.com/IBM/incubator/blob/master",
     "file": "tech-talk.md",
     "icon": "techtalk.svg",
-    "checklist":[]
+    "checklist":[{
+        "order": 1,
+        "comment": "Does the subject matter lend itself well to a tech talk?"
+      },
+      {
+        "order": 2,
+        "comment": "What is it's advocacy potential?"
+      },
+      {
+        "order": 3,
+        "comment": "Is the pattern or blog the talk is based on free to run?"
+      },
+      {
+        "order": 4,
+        "comment": "Is there code to be written?  Will there be a live demo?"
+      },
+      {
+        "order": 5,
+        "comment": "Are we inheriting code?"
+      },
+      {
+        "order": 6,
+        "comment": "What is its priority?"
+      },
+      {
+        "order": 7,
+        "comment": "Is it for a product or release launch?"
+      },
+      {
+        "order": 8,
+        "comment": "Does this tech talk fill a gap in our portfolio?"
+      },
+      {
+        "order": 9,
+        "comment": "Does it overlap with our existing portfolio?"
+      },
+      {
+        "order": 10,
+        "comment": "Can we partner up with a client?"
+      },
+      {
+        "order": 11,
+        "comment": "Does this tech talk highlight an IBM product advantage vs market products?"
+      }
+    ]
   },
   {
     "type": "workshop",
@@ -81,3 +154,4 @@
     "checklist":[]
   }
 ]
+


### PR DESCRIPTION
This commit adds checklists, and therefore issue creation pages,
for the how-to and tech talk publication types.