### PR TITLE
Specify shellcheck version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,6 @@
 language: node_js
 node_js: lts/*
 
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - shellcheck
-
 matrix:
   fast_finish: true
 
@@ -16,6 +9,9 @@ env:
   - TEST_RUN="echo Soon"
 
 before_install:
+  - curl -sSL "https://ftp-master.debian.org/keys/archive-key-7.0.asc" | sudo -E apt-key add -
+  - echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" | sudo tee -a /etc/apt/sources.list > /dev/null
+  - sudo apt-get install shellcheck=0.3.3-1~ubuntu14.04.1
   - npm install eslint html-lint csslint
   - sudo pip install yamllint
 


### PR DESCRIPTION
Previously, using travis' apt package install for shellcheck was
breaking builds.  This specifies the shellcheck version and installs
it.